### PR TITLE
DP aggregate updates

### DIFF
--- a/packages/core/src/dp/noisy_count_threshold.rs
+++ b/packages/core/src/dp/noisy_count_threshold.rs
@@ -1,15 +1,13 @@
-#[derive(Debug)]
+use super::InputValueByLen;
+
+#[derive(Debug, Clone)]
 /// Possible thresholds when adding noise with DP
 pub enum NoisyCountThreshold {
-    /// Filter combinations based on a fixed threshold
+    /// Filter combinations by combination length based on a fixed threshold
     /// (keep only noisy counts that are `> threshold`)
-    Fixed(f64),
-    /// Filter combinations based on a fraction of
+    Fixed(InputValueByLen<f64>),
+    /// Filter combinations by combination length based on a fraction of
     /// the fabricated counts distribution
-    /// (this should be a value between 0 and 1)
-    Adaptive(f64),
-    /// The threshold value will be the maximum fabrication percentage
-    /// (considering the original aggregate counts) allowed by combination length
-    /// (this should be a value between 0 and 1)
-    MaxFabrication(f64),
+    /// (this should be a value between 0 and 0.5)
+    Adaptive(InputValueByLen<f64>),
 }

--- a/packages/core/src/dp/typedefs.rs
+++ b/packages/core/src/dp/typedefs.rs
@@ -21,3 +21,6 @@ pub type CombinationsCountMap = FnvHashMap<Arc<ValueCombination>, f64>;
 /// Maps a value combination to its count but grouped by combination
 /// length
 pub type CombinationsCountMapByLen = FnvHashMap<usize, CombinationsCountMap>;
+
+/// Specifies an input value by combination length
+pub type InputValueByLen<T> = FnvHashMap<usize, T>;

--- a/packages/core/tests/dp/noise_aggregator.rs
+++ b/packages/core/tests/dp/noise_aggregator.rs
@@ -1,4 +1,6 @@
-use sds_core::dp::{CombinationsCountMapByLen, DpParameters, NoiseAggregator, NoisyCountThreshold};
+use sds_core::dp::{
+    CombinationsCountMapByLen, DpParameters, InputValueByLen, NoiseAggregator, NoisyCountThreshold,
+};
 
 use crate::utils::{
     assert_map_equals, gen_combinations_count_map, gen_value_combination, read_test_data_block,
@@ -13,7 +15,7 @@ fn get_noise_aggregator() -> NoiseAggregator {
         read_test_data_block(TEST_FILE_PATH, DELIMITER, &[], &[], 0),
         3,
         &DpParameters::new(1.0, 0.001, 99, 0.1, None),
-        NoisyCountThreshold::Fixed(10.0),
+        NoisyCountThreshold::Fixed(InputValueByLen::default()),
     )
 }
 

--- a/packages/lib-python/src/data_processor.rs
+++ b/packages/lib-python/src/data_processor.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 use sds_core::{
     data_block::{CsvDataBlockCreator, CsvIOError, DataBlock, DataBlockCreator},
     dp::DpParameters,
-    dp::{NoisyCountThreshold, StatsError},
+    dp::{InputValueByLen, NoisyCountThreshold, StatsError},
     processing::{
         aggregator::{AggregatedData, Aggregator},
         generator::{GeneratedData, Generator, OversamplingParameters},
@@ -84,7 +84,7 @@ impl SDSProcessor {
         &self,
         reporting_length: usize,
         dp_parameters: &DpParameters,
-        threshold: f64,
+        threshold: InputValueByLen<f64>,
     ) -> Result<AggregatedData, StatsError> {
         self.aggregate_with_dp(
             reporting_length,
@@ -97,25 +97,12 @@ impl SDSProcessor {
         &self,
         reporting_length: usize,
         dp_parameters: &DpParameters,
-        threshold: f64,
+        threshold: InputValueByLen<f64>,
     ) -> Result<AggregatedData, StatsError> {
         self.aggregate_with_dp(
             reporting_length,
             dp_parameters,
             NoisyCountThreshold::Adaptive(threshold),
-        )
-    }
-
-    fn aggregate_with_dp_max_fabrication_threshold(
-        &self,
-        reporting_length: usize,
-        dp_parameters: &DpParameters,
-        threshold: f64,
-    ) -> Result<AggregatedData, StatsError> {
-        self.aggregate_with_dp(
-            reporting_length,
-            dp_parameters,
-            NoisyCountThreshold::MaxFabrication(threshold),
         )
     }
 

--- a/packages/lib-wasm/src/processing/sds_context.rs
+++ b/packages/lib-wasm/src/processing/sds_context.rs
@@ -3,12 +3,13 @@ use super::{
     navigator::WasmNavigateResult, sds_processor::SDSProcessor,
 };
 use log::debug;
-use sds_core::dp::NoisyCountThreshold;
+use sds_core::dp::{InputValueByLen, NoisyCountThreshold};
 use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::utils::js::{
     JsAggregateResult, JsAttributesIntersectionByColumn, JsEvaluateResult, JsGenerateResult,
-    JsHeaderNames, JsReportProgressCallback, JsResult, JsSelectedAttributesByColumn,
+    JsHeaderNames, JsInputNumberByLength, JsReportProgressCallback, JsResult,
+    JsSelectedAttributesByColumn,
 };
 
 #[wasm_bindgen]
@@ -318,7 +319,7 @@ impl SDSContext {
         percentile_percentage: usize,
         percentile_epsilon_proportion: f64,
         sigma_proportions: Option<Vec<f64>>,
-        threshold: f64,
+        threshold: JsInputNumberByLength,
         use_synthetic_counts: bool,
         sensitive_aggregates_progress_callback: JsReportProgressCallback,
         reportable_aggregates_progress_callback: JsReportProgressCallback,
@@ -333,7 +334,7 @@ impl SDSContext {
             percentile_percentage,
             percentile_epsilon_proportion,
             sigma_proportions,
-            NoisyCountThreshold::Fixed(threshold),
+            NoisyCountThreshold::Fixed(InputValueByLen::<f64>::try_from(threshold)?),
             use_synthetic_counts,
             sensitive_aggregates_progress_callback,
             reportable_aggregates_progress_callback,
@@ -353,7 +354,7 @@ impl SDSContext {
         percentile_percentage: usize,
         percentile_epsilon_proportion: f64,
         sigma_proportions: Option<Vec<f64>>,
-        threshold: f64,
+        threshold: JsInputNumberByLength,
         use_synthetic_counts: bool,
         sensitive_aggregates_progress_callback: JsReportProgressCallback,
         reportable_aggregates_progress_callback: JsReportProgressCallback,
@@ -368,42 +369,7 @@ impl SDSContext {
             percentile_percentage,
             percentile_epsilon_proportion,
             sigma_proportions,
-            NoisyCountThreshold::Adaptive(threshold),
-            use_synthetic_counts,
-            sensitive_aggregates_progress_callback,
-            reportable_aggregates_progress_callback,
-            synthesis_progress_callback,
-        )
-    }
-
-    #[wasm_bindgen(js_name = "generateDpMaxFabricationThreshold")]
-    #[allow(clippy::too_many_arguments)]
-    pub fn generate_dp_max_fabrication_threshold(
-        &mut self,
-        resolution: usize,
-        empty_value: String,
-        reporting_length: usize,
-        epsilon: f64,
-        delta: f64,
-        percentile_percentage: usize,
-        percentile_epsilon_proportion: f64,
-        sigma_proportions: Option<Vec<f64>>,
-        threshold: f64,
-        use_synthetic_counts: bool,
-        sensitive_aggregates_progress_callback: JsReportProgressCallback,
-        reportable_aggregates_progress_callback: JsReportProgressCallback,
-        synthesis_progress_callback: JsReportProgressCallback,
-    ) -> JsResult<()> {
-        self.generate_dp(
-            resolution,
-            empty_value,
-            reporting_length,
-            epsilon,
-            delta,
-            percentile_percentage,
-            percentile_epsilon_proportion,
-            sigma_proportions,
-            NoisyCountThreshold::MaxFabrication(threshold),
+            NoisyCountThreshold::Adaptive(InputValueByLen::<f64>::try_from(threshold)?),
             use_synthetic_counts,
             sensitive_aggregates_progress_callback,
             reportable_aggregates_progress_callback,

--- a/packages/lib-wasm/src/processing/sds_processor/input_number_by_length.rs
+++ b/packages/lib-wasm/src/processing/sds_processor/input_number_by_length.rs
@@ -1,0 +1,14 @@
+use sds_core::dp::InputValueByLen;
+use wasm_bindgen::JsValue;
+
+use crate::utils::js::JsInputNumberByLength;
+
+impl TryFrom<JsInputNumberByLength> for InputValueByLen<f64> {
+    type Error = JsValue;
+
+    fn try_from(input_number_by_length: JsInputNumberByLength) -> Result<Self, Self::Error> {
+        input_number_by_length
+            .into_serde::<InputValueByLen<f64>>()
+            .map_err(|err| JsValue::from(err.to_string()))
+    }
+}

--- a/packages/lib-wasm/src/processing/sds_processor/mod.rs
+++ b/packages/lib-wasm/src/processing/sds_processor/mod.rs
@@ -1,5 +1,7 @@
 mod header_names;
+mod input_number_by_length;
 mod processor;
 
 pub use header_names::*;
+pub use input_number_by_length::*;
 pub use processor::*;

--- a/packages/lib-wasm/src/processing/sds_processor/processor.rs
+++ b/packages/lib-wasm/src/processing/sds_processor/processor.rs
@@ -2,7 +2,7 @@ use csv::ReaderBuilder;
 use js_sys::Function;
 use sds_core::{
     data_block::{CsvDataBlockCreator, CsvRecord, DataBlock, DataBlockCreator},
-    dp::{DpParameters, NoisyCountThreshold},
+    dp::{DpParameters, InputValueByLen, NoisyCountThreshold},
     processing::{
         aggregator::Aggregator,
         generator::{Generator, OversamplingParameters},
@@ -14,7 +14,7 @@ use std::{convert::TryFrom, io::Cursor};
 use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{
-    utils::js::JsProgressReporter,
+    utils::js::{JsInputNumberByLength, JsProgressReporter},
     {
         processing::{aggregator::WasmAggregateResult, generator::WasmGenerateResult},
         utils::js::{JsHeaderNames, JsReportProgressCallback},
@@ -138,7 +138,7 @@ impl SDSProcessor {
         percentile_percentage: usize,
         percentile_epsilon_proportion: f64,
         sigma_proportions: Option<Vec<f64>>,
-        threshold: f64,
+        threshold: JsInputNumberByLength,
         progress_callback: JsReportProgressCallback,
     ) -> Result<WasmAggregateResult, JsValue> {
         self.aggregate_with_dp(
@@ -148,7 +148,7 @@ impl SDSProcessor {
             percentile_percentage,
             percentile_epsilon_proportion,
             sigma_proportions,
-            NoisyCountThreshold::Fixed(threshold),
+            NoisyCountThreshold::Fixed(InputValueByLen::<f64>::try_from(threshold)?),
             progress_callback,
         )
     }
@@ -163,7 +163,7 @@ impl SDSProcessor {
         percentile_percentage: usize,
         percentile_epsilon_proportion: f64,
         sigma_proportions: Option<Vec<f64>>,
-        threshold: f64,
+        threshold: JsInputNumberByLength,
         progress_callback: JsReportProgressCallback,
     ) -> Result<WasmAggregateResult, JsValue> {
         self.aggregate_with_dp(
@@ -173,32 +173,7 @@ impl SDSProcessor {
             percentile_percentage,
             percentile_epsilon_proportion,
             sigma_proportions,
-            NoisyCountThreshold::Adaptive(threshold),
-            progress_callback,
-        )
-    }
-
-    #[wasm_bindgen(js_name = "aggregateWithDpMaxFabricationThreshold")]
-    #[allow(clippy::too_many_arguments)]
-    pub fn aggregate_with_dp_max_fabrication_threshold(
-        &self,
-        reporting_length: usize,
-        epsilon: f64,
-        delta: f64,
-        percentile_percentage: usize,
-        percentile_epsilon_proportion: f64,
-        sigma_proportions: Option<Vec<f64>>,
-        threshold: f64,
-        progress_callback: JsReportProgressCallback,
-    ) -> Result<WasmAggregateResult, JsValue> {
-        self.aggregate_with_dp(
-            reporting_length,
-            epsilon,
-            delta,
-            percentile_percentage,
-            percentile_epsilon_proportion,
-            sigma_proportions,
-            NoisyCountThreshold::MaxFabrication(threshold),
+            NoisyCountThreshold::Adaptive(InputValueByLen::<f64>::try_from(threshold)?),
             progress_callback,
         )
     }

--- a/packages/lib-wasm/src/utils/js/ts_definitions.rs
+++ b/packages/lib-wasm/src/utils/js/ts_definitions.rs
@@ -6,6 +6,10 @@ export type ReportProgressCallback = (progress: number) => void
 
 export type HeaderNames = string[]
 
+export interface IInputNumberByLength {
+  [length: number]: number
+}
+
 export interface IGenerateResult {
   expansionRatio: number
   syntheticData: string
@@ -71,6 +75,9 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "HeaderNames")]
     pub type JsHeaderNames;
+
+    #[wasm_bindgen(typescript_type = "IInputNumberByLength")]
+    pub type JsInputNumberByLength;
 
     #[wasm_bindgen(typescript_type = "IGenerateResult")]
     pub type JsGenerateResult;

--- a/packages/python-pipeline/src/aggregator.py
+++ b/packages/python-pipeline/src/aggregator.py
@@ -41,7 +41,7 @@ def aggregate(config):
     noise_epsilon = config['noise_epsilon']
     noise_delta = config['noise_delta']
     noise_threshold_type = config['noise_threshold_type']
-    noise_threshold_value = config['noise_threshold_value']
+    noise_threshold_values = config['noise_threshold_values']
 
     logging.info(f'Aggregate {sensitive_microdata_path}')
     start_time = time.time()
@@ -84,7 +84,7 @@ def aggregate(config):
                     percentile_epsilon_proportion,
                     sigma_proportions
                 ),
-                noise_threshold_value
+                noise_threshold_values
             )
         elif noise_threshold_type == 'adaptive':
             aggregated_data = sds_processor.aggregate_with_dp_adaptive_threshold(
@@ -96,19 +96,7 @@ def aggregate(config):
                     percentile_epsilon_proportion,
                     sigma_proportions
                 ),
-                noise_threshold_value
-            )
-        elif noise_threshold_type == 'max_fabrication':
-            aggregated_data = sds_processor.aggregate_with_dp_max_fabrication_threshold(
-                reporting_length,
-                sds.DpParameters(
-                    noise_epsilon,
-                    noise_delta,
-                    percentile_percentage,
-                    percentile_epsilon_proportion,
-                    sigma_proportions
-                ),
-                noise_threshold_value
+                noise_threshold_values
             )
         else:
             raise ValueError(

--- a/packages/python-pipeline/src/showcase.py
+++ b/packages/python-pipeline/src/showcase.py
@@ -87,7 +87,8 @@ def runForConfig(config):
     config['noise_threshold_type'] = config.get('noise_threshold_type', None)
     if config['noise_threshold_type'] != None:
         config['noise_threshold_type'] = config['noise_threshold_type'].lower()
-    config['noise_threshold_value'] = config.get('noise_threshold_value', None)
+    config['noise_threshold_values'] = {
+        int(l): t for l, t in config.get('noise_threshold_values', {}).items()}
 
     # parameters affecting the representation and interpretation of values
     config['sensitive_zeros'] = config.get('sensitive_zeros', [])

--- a/packages/webapp/src/components/Pages/DataShowcasePage/DataSynthesis/hooks/useNoisyCountThresholdTypeOptions.ts
+++ b/packages/webapp/src/components/Pages/DataShowcasePage/DataSynthesis/hooks/useNoisyCountThresholdTypeOptions.ts
@@ -12,10 +12,6 @@ const noisyCountThresholdTypeOptions = [
 		key: NoisyCountThresholdType.Adaptive,
 		text: NoisyCountThresholdType.Adaptive,
 	},
-	{
-		key: NoisyCountThresholdType.MaxFabrication,
-		text: NoisyCountThresholdType.MaxFabrication,
-	},
 ]
 
 export function useNoisyCountThresholdTypeOptions(): IDropdownOption[] {

--- a/packages/webapp/src/models/synthesis/NoisyCountThresholdType.ts
+++ b/packages/webapp/src/models/synthesis/NoisyCountThresholdType.ts
@@ -5,5 +5,4 @@
 export enum NoisyCountThresholdType {
 	Fixed = 'Fixed',
 	Adaptive = 'Adaptive',
-	MaxFabrication = 'MaxFabrication',
 }

--- a/packages/webapp/src/states/dataShowcaseContext/noisyCountThresholdType.ts
+++ b/packages/webapp/src/states/dataShowcaseContext/noisyCountThresholdType.ts
@@ -9,7 +9,7 @@ import { NoisyCountThresholdType } from '~models'
 
 const state = atom<NoisyCountThresholdType>({
 	key: 'noisy-count-threshold-type',
-	default: NoisyCountThresholdType.MaxFabrication,
+	default: NoisyCountThresholdType.Adaptive,
 })
 
 export function useNoisyCountThresholdType(): [

--- a/packages/webapp/src/ui-tooltips/mds/THRESHOLD_TYPE.md
+++ b/packages/webapp/src/ui-tooltips/mds/THRESHOLD_TYPE.md
@@ -4,8 +4,4 @@ Possible thresholds when adding noise with DP:
 Filter combinations based on a fixed threshold (keep only noisy counts that are `> threshold`)
 
 **`Adaptive`**:
-Filter combinations based on a fraction of the fabricated counts distribution (this should be a value between 0 and 1)
-
-**`MaxFabrication`**:
-The threshold value will be the maximum fabrication percentage (considering the original aggregate counts) allowed by combination length (this should be a value between 0 and 1)
-
+Filter combinations based on a fraction of the fabricated counts distribution (this should be a value between 0 and 0.5)

--- a/packages/webapp/src/workers/sds-wasm/worker.ts
+++ b/packages/webapp/src/workers/sds-wasm/worker.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
+import type { IInputNumberByLength } from 'sds-wasm'
 import init, { init_logger, SDSContext } from 'sds-wasm'
 
 import {
@@ -103,6 +104,13 @@ async function handleGenerate(
 		context: new SDSContext(),
 		contextParameters: message.contextParameters,
 	}).context
+	const thresholdValues: IInputNumberByLength = {}
+
+	// do this for now while the UI does not support
+	// the multi-value input
+	for (let i = 2; i <= message.contextParameters.reportingLength; ++i) {
+		thresholdValues[i] = message.contextParameters.thresholdValue
+	}
 
 	context.setSensitiveData(
 		message.sensitiveCsvData,
@@ -181,7 +189,7 @@ async function handleGenerate(
 						message.contextParameters.percentilePercentage,
 						message.contextParameters.percentileEpsilonProportion,
 						undefined,
-						message.contextParameters.thresholdValue,
+						thresholdValues,
 						message.contextParameters.useSyntheticCounts ===
 							UseSyntheticCounts.Yes,
 						p => {
@@ -205,31 +213,7 @@ async function handleGenerate(
 						message.contextParameters.percentilePercentage,
 						message.contextParameters.percentileEpsilonProportion,
 						undefined,
-						message.contextParameters.thresholdValue,
-						message.contextParameters.useSyntheticCounts ===
-							UseSyntheticCounts.Yes,
-						p => {
-							postProgress(message.id, 0.25 * p)
-						},
-						p => {
-							postProgress(message.id, 25.0 + 0.25 * p)
-						},
-						p => {
-							postProgress(message.id, 50.0 + 0.5 * p)
-						},
-					)
-					break
-				case NoisyCountThresholdType.MaxFabrication:
-					context.generateDpMaxFabricationThreshold(
-						message.contextParameters.resolution,
-						message.contextParameters.emptyValue,
-						message.contextParameters.reportingLength,
-						message.contextParameters.noiseEpsilon,
-						message.contextParameters.noiseDelta,
-						message.contextParameters.percentilePercentage,
-						message.contextParameters.percentileEpsilonProportion,
-						undefined,
-						message.contextParameters.thresholdValue,
+						thresholdValues,
 						message.contextParameters.useSyntheticCounts ===
 							UseSyntheticCounts.Yes,
 						p => {


### PR DESCRIPTION
- DP aggregates updates
    - Use correct threshold for 1-counts
    - Update adaptive threshold to allow more flexibility over fabrication
    - Remove max fabrication threshold (we should use the adaptive one instead)
- DP aggregate bugfixes
- Updating cli, lib-wasm and lib-python accordingly