### PR TITLE
Hotfixes for version 1.5.0

### DIFF
--- a/packages/lib-wasm/src/processing/evaluator/evaluate_result.rs
+++ b/packages/lib-wasm/src/processing/evaluator/evaluate_result.rs
@@ -15,6 +15,7 @@ pub struct WasmEvaluateResult {
     aggregate_counts_stats: WasmMicrodataStatistics,
     sensitive_data_stats: WasmMicrodataStatistics,
     synthetic_data_stats: WasmMicrodataStatistics,
+    synthetic_vs_aggregate_data_stats: WasmMicrodataStatistics,
     reporting_length: usize,
 }
 
@@ -41,6 +42,11 @@ impl WasmEvaluateResult {
             )?,
             synthetic_data_stats: WasmMicrodataStatistics::from_aggregate_results(
                 sensitive_aggregate_result,
+                synthetic_aggregate_result,
+                resolution,
+            )?,
+            synthetic_vs_aggregate_data_stats: WasmMicrodataStatistics::from_aggregate_results(
+                reportable_aggregate_result,
                 synthetic_aggregate_result,
                 resolution,
             )?,
@@ -73,6 +79,11 @@ impl WasmEvaluateResult {
             &result,
             &"syntheticDataStats".into(),
             &self.synthetic_data_stats.to_js()?.into(),
+        )?;
+        set(
+            &result,
+            &"syntheticVsAggregateDataStats".into(),
+            &self.synthetic_vs_aggregate_data_stats.to_js()?.into(),
         )?;
 
         Ok(JsValue::from(result).unchecked_into::<JsEvaluateResult>())

--- a/packages/lib-wasm/src/utils/js/ts_definitions.rs
+++ b/packages/lib-wasm/src/utils/js/ts_definitions.rs
@@ -110,6 +110,7 @@ export interface IEvaluateResult {
   aggregateCountsStats: IMicrodataStatistics
   sensitiveDataStats: IMicrodataStatistics
   syntheticDataStats: IMicrodataStatistics
+  syntheticVsAggregateDataStats: IMicrodataStatistics
 }
 
 export interface ISelectedAttributesByColumn {

--- a/packages/webapp/src/components/HumanReadableSummary/HumanReadableSummary.hooks.ts
+++ b/packages/webapp/src/components/HumanReadableSummary/HumanReadableSummary.hooks.ts
@@ -88,10 +88,12 @@ export function useSyntheticDataPrivacyText(
 				return `For all attribute combinations of any length, none describe groups of data subjects smaller than the privacy resolution (guaranteed by k-anonymity).`
 
 			case SynthesisMode.AggregateSeeded:
-				return `For all attribute combinations of up to 4 attributes, none describe groups of data subjects smaller than the privacy resolution (guaranteed by k-anonymity).`
+				return `For all attribute combinations of up to ${synthesisInfo.parameters.reportingLength} attributes, none describe groups of data subjects smaller than the privacy resolution (guaranteed by k-anonymity).`
 
 			case SynthesisMode.DP:
-				return `For all attribute combinations of up to 4 attributes, ${leakagePercentage.toFixed(
+				return `For all attribute combinations of up to ${
+					synthesisInfo.parameters.reportingLength
+				} attributes, ${leakagePercentage.toFixed(
 					2,
 				)}% describe groups of data subjects smaller than the privacy resolution (but protected by differential privacy).`
 		}
@@ -104,7 +106,9 @@ export function useSyntheticDataUtilityText(
 ): string {
 	return useMemo(() => {
 		const retainedCombinationsPercentage =
-			100 - evaluateResult.syntheticDataStats.percentageOfSuppressedCombinations
+			100 -
+			evaluateResult.syntheticVsAggregateDataStats
+				.percentageOfSuppressedCombinations
 
 		switch (synthesisInfo.parameters.mode) {
 			case SynthesisMode.Unseeded:
@@ -115,7 +119,7 @@ export function useSyntheticDataUtilityText(
 					synthesisInfo.parameters.reportingLength
 				} attributes, ${retainedCombinationsPercentage.toFixed(
 					2,
-				)}% of the combinations in the sensitive dataset are retained in the synthetic dataset. All released combinations were present in the sensitive dataset and the average error of counts derived from this synthetic data is ${evaluateResult.syntheticDataStats.combinationsCountMeanAbsError.toFixed(
+				)}% of the reported combinations in the aggregate dataset are retained in the synthetic dataset. All released combinations were present in the sensitive dataset and the average error of synthetic counts is ${evaluateResult.syntheticDataStats.combinationsCountMeanAbsError.toFixed(
 					2,
 				)}.`
 
@@ -124,7 +128,7 @@ export function useSyntheticDataUtilityText(
 					synthesisInfo.parameters.reportingLength
 				} attributes, ${retainedCombinationsPercentage.toFixed(
 					2,
-				)}% of the combinations in the sensitive dataset are retained in the synthetic dataset. The average error of counts derived from this synthetic data is ${evaluateResult.syntheticDataStats.combinationsCountMeanAbsError.toFixed(
+				)}% of the reported combinations in the aggregate dataset are retained in the synthetic dataset. The average error of synthetic counts is ${evaluateResult.syntheticDataStats.combinationsCountMeanAbsError.toFixed(
 					2,
 				)}.`
 		}

--- a/packages/webapp/src/components/SynthesisDropdown/SynthesisDropdown.tsx
+++ b/packages/webapp/src/components/SynthesisDropdown/SynthesisDropdown.tsx
@@ -31,6 +31,10 @@ export const SynthesisDropdown: React.FC<SynthesisDropdownProps> = memo(
 				placeholder="Select"
 				options={allSynthesisOptions}
 				disabled={disabled}
+				styles={{
+					dropdownOptionText: { overflow: 'visible', whiteSpace: 'normal' },
+					dropdownItem: { height: 'auto' },
+				}}
 			/>
 		)
 	},

--- a/packages/webapp/src/ui-tooltips/mds/USE_SYNTHETIC_COUNTS.md
+++ b/packages/webapp/src/ui-tooltips/mds/USE_SYNTHETIC_COUNTS.md
@@ -3,5 +3,3 @@ Indicates wether the attribute combination counts of the already synthesized rec
 - If **No**: the sampling process will take into account only then plain reportable aggregate counts to balance the sampling process
 
 - If **Yes**: the sampling process will take into account both then plain reportable aggregate counts and the already synthesized counts to balance the sampling process
-
-For **DP** mode, generally setting this do **No** leads to more accurate results.


### PR DESCRIPTION
- wrapping text on synthesis dropdown
- updating wasm api to include syntheticVsAggregateDataStats
- updating human readable statistics