### PR TITLE
Using record_count token to identify number of records in aggregates file

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,7 +53,7 @@ _aggregates.tsv_
 
 ```tsv
 selections	protected_count
-selections	10
+record_count	10
 B:b2;D:d2	4
 A:a1;B:b1;C:c1	2
 A:a1	4

--- a/packages/core/src/processing/aggregator/aggregated_data.rs
+++ b/packages/core/src/processing/aggregator/aggregated_data.rs
@@ -179,7 +179,7 @@ impl AggregatedData {
             format!("selections{}{}\n", aggregates_delimiter, n_records_label).as_bytes(),
         )?;
         writer
-            .write_all(format!("selections{}{}\n", aggregates_delimiter, n_records).as_bytes())?;
+            .write_all(format!("record_count{}{}\n", aggregates_delimiter, n_records).as_bytes())?;
 
         for aggregate in self.aggregates_count.keys() {
             writer.write_all(


### PR DESCRIPTION
- using `record_count` token to identify number of records in aggregates file