### PR TITLE
Case insensitive order for aggregates exported from the UI (PBI compatibility)

### DIFF
--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -459,6 +459,7 @@ fn main() {
                     &aggregates_path,
                     aggregates_delimiter.chars().next().unwrap(),
                     ";",
+                    None,
                 ) {
                     error!("error writing output file: {}", err);
                     process::exit(1);

--- a/packages/core/src/processing/aggregator/value_combination.rs
+++ b/packages/core/src/processing/aggregator/value_combination.rs
@@ -59,6 +59,28 @@ impl ValueCombination {
         str
     }
 
+    /// Formats a value combination as String using the headers.
+    /// The order of the combination output will be sorted using a case
+    /// insensitive comparison.
+    /// The result is formatted as:
+    /// `{header_name}:{block_value};{header_name}:{block_value}...`
+    /// # Arguments
+    /// * `headers` - Data block headers
+    /// * `combination_delimiter` - Delimiter used to join combinations
+    pub fn as_str_using_headers_case_insensitive_order(
+        &self,
+        headers: &DataBlockHeadersSlice,
+        combination_delimiter: &str,
+    ) -> String {
+        let mut vc = (*self).clone();
+
+        // sort the combination using case insensitive ordering
+        vc.combination
+            .sort_by_key(|k| k.as_str_using_headers(headers).to_lowercase());
+
+        vc.as_str_using_headers(headers, combination_delimiter)
+    }
+
     /// Creates a new set containing the combination values
     #[inline]
     pub fn build_ref_set(&self) -> ValueCombinationRefSet {

--- a/packages/lib-wasm/src/processing/aggregator/aggregate_result.rs
+++ b/packages/lib-wasm/src/processing/aggregator/aggregate_result.rs
@@ -65,9 +65,14 @@ impl WasmAggregateResult {
         &self,
         aggregates_delimiter: char,
         combination_delimiter: &str,
+        case_insensitive_combinations_order: Option<bool>,
     ) -> JsResult<String> {
         self.aggregated_data
-            .write_aggregates_to_string(aggregates_delimiter, combination_delimiter)
+            .write_aggregates_to_string(
+                aggregates_delimiter,
+                combination_delimiter,
+                case_insensitive_combinations_order,
+            )
             .map_err(|err| JsValue::from(err.to_string()))
     }
 
@@ -76,6 +81,7 @@ impl WasmAggregateResult {
         &self,
         aggregates_delimiter: char,
         combination_delimiter: &str,
+        case_insensitive_combinations_order: Option<bool>,
     ) -> JsResult<JsAggregateResult> {
         let _duration_logger =
             ElapsedDurationLogger::new(String::from("aggregate result serialization"));
@@ -90,7 +96,11 @@ impl WasmAggregateResult {
             &result,
             &"aggregatesData".into(),
             &self
-                .aggregates_count_to_js(aggregates_delimiter, combination_delimiter)?
+                .aggregates_count_to_js(
+                    aggregates_delimiter,
+                    combination_delimiter,
+                    case_insensitive_combinations_order,
+                )?
                 .into(),
         )?;
 

--- a/packages/lib-wasm/src/processing/sds_context/context.rs
+++ b/packages/lib-wasm/src/processing/sds_context/context.rs
@@ -328,9 +328,13 @@ impl WasmSdsContext {
         &self,
         aggregates_delimiter: char,
         combination_delimiter: &str,
+        case_insensitive_combinations_order: Option<bool>,
     ) -> JsResult<JsAggregateResult> {
-        self.get_sensitive_aggregate_result()?
-            .to_js(aggregates_delimiter, combination_delimiter)
+        self.get_sensitive_aggregate_result()?.to_js(
+            aggregates_delimiter,
+            combination_delimiter,
+            case_insensitive_combinations_order,
+        )
     }
 
     #[wasm_bindgen(js_name = "reportableAggregateResultToJs")]
@@ -338,9 +342,13 @@ impl WasmSdsContext {
         &self,
         aggregates_delimiter: char,
         combination_delimiter: &str,
+        case_insensitive_combinations_order: Option<bool>,
     ) -> JsResult<JsAggregateResult> {
-        self.get_reportable_aggregate_result()?
-            .to_js(aggregates_delimiter, combination_delimiter)
+        self.get_reportable_aggregate_result()?.to_js(
+            aggregates_delimiter,
+            combination_delimiter,
+            case_insensitive_combinations_order,
+        )
     }
 
     #[wasm_bindgen(js_name = "syntheticAggregateResultToJs")]
@@ -348,9 +356,13 @@ impl WasmSdsContext {
         &self,
         aggregates_delimiter: char,
         combination_delimiter: &str,
+        case_insensitive_combinations_order: Option<bool>,
     ) -> JsResult<JsAggregateResult> {
-        self.get_synthetic_aggregate_result()?
-            .to_js(aggregates_delimiter, combination_delimiter)
+        self.get_synthetic_aggregate_result()?.to_js(
+            aggregates_delimiter,
+            combination_delimiter,
+            case_insensitive_combinations_order,
+        )
     }
 
     #[wasm_bindgen(js_name = "navigateResultToJs")]

--- a/packages/webapp/src/components/DataEvaluationInfoDownloader/hooks.ts
+++ b/packages/webapp/src/components/DataEvaluationInfoDownloader/hooks.ts
@@ -122,6 +122,9 @@ export async function getAggregatesCsv(
 		aggregateType,
 		aggregatesDelimiter,
 		combinationDelimiter,
+		// case insensitive sort on combinations values
+		// so it works nice with the PBI report
+		true,
 	)
 	return result?.aggregatesData || ''
 }

--- a/packages/webapp/src/workers/SdsManager.ts
+++ b/packages/webapp/src/workers/SdsManager.ts
@@ -210,6 +210,7 @@ export class SdsManager {
 		aggregateType: AggregateType,
 		aggregatesDelimiter: string,
 		combinationDelimiter: string,
+		caseInsensitiveCombinationsOrder = false,
 	): Promise<IAggregateResult> {
 		return await this.getSynthesizerWorkInfo(
 			key,
@@ -217,6 +218,7 @@ export class SdsManager {
 			aggregateType,
 			aggregatesDelimiter,
 			combinationDelimiter,
+			caseInsensitiveCombinationsOrder,
 		)
 	}
 

--- a/packages/webapp/src/workers/WasmSynthesizer.ts
+++ b/packages/webapp/src/workers/WasmSynthesizer.ts
@@ -110,6 +110,7 @@ export class WasmSynthesizer extends BaseSdsWasmWorker {
 		aggregateType: AggregateType,
 		aggregatesDelimiter: string,
 		combinationDelimiter: string,
+		caseInsensitiveCombinationsOrder = false,
 	): Promise<IAggregateResult> {
 		const context = this.getContext()
 
@@ -118,16 +119,19 @@ export class WasmSynthesizer extends BaseSdsWasmWorker {
 				return context.sensitiveAggregateResultToJs(
 					aggregatesDelimiter,
 					combinationDelimiter,
+					caseInsensitiveCombinationsOrder,
 				)
 			case AggregateType.Aggregated:
 				return context.reportableAggregateResultToJs(
 					aggregatesDelimiter,
 					combinationDelimiter,
+					caseInsensitiveCombinationsOrder,
 				)
 			case AggregateType.Synthetic:
 				return context.syntheticAggregateResultToJs(
 					aggregatesDelimiter,
 					combinationDelimiter,
+					caseInsensitiveCombinationsOrder,
 				)
 		}
 	}


### PR DESCRIPTION
- Case insensitive order for aggregates exported from the UI (PBI compatibility)
- Sort export aggregates by combination length ascending and count descending