### PR TITLE
Case insensitive order for aggregates exported from the UI (PBI compatibility)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sds-cli"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "csv",
  "env_logger",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "sds-core"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "csv",
  "fnv",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "sds-pyo3"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "csv",
  "env_logger",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "sds-wasm"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "console_error_panic_hook",
  "csv",

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 > Generates synthetic data and user interfaces for privacy-preserving data sharing and analysis.
 
+> Free-to-use web application for private data release: https://microsoft.github.io/synthetic-data-showcase/
+
 # Overview
 
 In many cases, the best way to share sensitive datasets is not to share the actual sensitive datasets, but user interfaces to derived datasets that are inherently anonymous. Our name for such an interface is a _data showcase_. In this project, we provide an automated set of tools for generating the three elements of a _synthetic data showcase_:

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sds-cli"
-version = "1.8.2"
+version = "1.8.3"
 license = "MIT"
 description = "Command line interface for the sds-core library"
 repository = "https://github.com/microsoft/synthetic-data-showcase"

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -459,6 +459,7 @@ fn main() {
                     &aggregates_path,
                     aggregates_delimiter.chars().next().unwrap(),
                     ";",
+                    None,
                 ) {
                     error!("error writing output file: {}", err);
                     process::exit(1);

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sds-core"
-version = "1.8.2"
+version = "1.8.3"
 license = "MIT"
 description = "Synthetic data showcase core library"
 repository = "https://github.com/microsoft/synthetic-data-showcase"

--- a/packages/core/src/processing/aggregator/value_combination.rs
+++ b/packages/core/src/processing/aggregator/value_combination.rs
@@ -59,6 +59,28 @@ impl ValueCombination {
         str
     }
 
+    /// Formats a value combination as String using the headers.
+    /// The order of the combination output will be sorted using a case
+    /// insensitive comparison.
+    /// The result is formatted as:
+    /// `{header_name}:{block_value};{header_name}:{block_value}...`
+    /// # Arguments
+    /// * `headers` - Data block headers
+    /// * `combination_delimiter` - Delimiter used to join combinations
+    pub fn as_str_using_headers_case_insensitive_order(
+        &self,
+        headers: &DataBlockHeadersSlice,
+        combination_delimiter: &str,
+    ) -> String {
+        let mut vc = (*self).clone();
+
+        // sort the combination using case insensitive ordering
+        vc.combination
+            .sort_by_key(|k| k.as_str_using_headers(headers).to_lowercase());
+
+        vc.as_str_using_headers(headers, combination_delimiter)
+    }
+
     /// Creates a new set containing the combination values
     #[inline]
     pub fn build_ref_set(&self) -> ValueCombinationRefSet {

--- a/packages/lib-python/Cargo.toml
+++ b/packages/lib-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sds-pyo3"
-version = "1.8.2"
+version = "1.8.3"
 license = "MIT"
 description = "Python bindings for the sds-core library"
 repository = "https://github.com/microsoft/synthetic-data-showcase"

--- a/packages/lib-wasm/Cargo.toml
+++ b/packages/lib-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sds-wasm"
-version = "1.8.2"
+version = "1.8.3"
 license = "MIT"
 description = "Web Assembly bindings for the sds-core library"
 repository = "https://github.com/microsoft/synthetic-data-showcase"

--- a/packages/lib-wasm/src/processing/aggregator/aggregate_result.rs
+++ b/packages/lib-wasm/src/processing/aggregator/aggregate_result.rs
@@ -65,9 +65,14 @@ impl WasmAggregateResult {
         &self,
         aggregates_delimiter: char,
         combination_delimiter: &str,
+        case_insensitive_combinations_order: Option<bool>,
     ) -> JsResult<String> {
         self.aggregated_data
-            .write_aggregates_to_string(aggregates_delimiter, combination_delimiter)
+            .write_aggregates_to_string(
+                aggregates_delimiter,
+                combination_delimiter,
+                case_insensitive_combinations_order,
+            )
             .map_err(|err| JsValue::from(err.to_string()))
     }
 
@@ -76,6 +81,7 @@ impl WasmAggregateResult {
         &self,
         aggregates_delimiter: char,
         combination_delimiter: &str,
+        case_insensitive_combinations_order: Option<bool>,
     ) -> JsResult<JsAggregateResult> {
         let _duration_logger =
             ElapsedDurationLogger::new(String::from("aggregate result serialization"));
@@ -90,7 +96,11 @@ impl WasmAggregateResult {
             &result,
             &"aggregatesData".into(),
             &self
-                .aggregates_count_to_js(aggregates_delimiter, combination_delimiter)?
+                .aggregates_count_to_js(
+                    aggregates_delimiter,
+                    combination_delimiter,
+                    case_insensitive_combinations_order,
+                )?
                 .into(),
         )?;
 

--- a/packages/lib-wasm/src/processing/sds_context/context.rs
+++ b/packages/lib-wasm/src/processing/sds_context/context.rs
@@ -328,9 +328,13 @@ impl WasmSdsContext {
         &self,
         aggregates_delimiter: char,
         combination_delimiter: &str,
+        case_insensitive_combinations_order: Option<bool>,
     ) -> JsResult<JsAggregateResult> {
-        self.get_sensitive_aggregate_result()?
-            .to_js(aggregates_delimiter, combination_delimiter)
+        self.get_sensitive_aggregate_result()?.to_js(
+            aggregates_delimiter,
+            combination_delimiter,
+            case_insensitive_combinations_order,
+        )
     }
 
     #[wasm_bindgen(js_name = "reportableAggregateResultToJs")]
@@ -338,9 +342,13 @@ impl WasmSdsContext {
         &self,
         aggregates_delimiter: char,
         combination_delimiter: &str,
+        case_insensitive_combinations_order: Option<bool>,
     ) -> JsResult<JsAggregateResult> {
-        self.get_reportable_aggregate_result()?
-            .to_js(aggregates_delimiter, combination_delimiter)
+        self.get_reportable_aggregate_result()?.to_js(
+            aggregates_delimiter,
+            combination_delimiter,
+            case_insensitive_combinations_order,
+        )
     }
 
     #[wasm_bindgen(js_name = "syntheticAggregateResultToJs")]
@@ -348,9 +356,13 @@ impl WasmSdsContext {
         &self,
         aggregates_delimiter: char,
         combination_delimiter: &str,
+        case_insensitive_combinations_order: Option<bool>,
     ) -> JsResult<JsAggregateResult> {
-        self.get_synthetic_aggregate_result()?
-            .to_js(aggregates_delimiter, combination_delimiter)
+        self.get_synthetic_aggregate_result()?.to_js(
+            aggregates_delimiter,
+            combination_delimiter,
+            case_insensitive_combinations_order,
+        )
     }
 
     #[wasm_bindgen(js_name = "navigateResultToJs")]

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "webapp",
-	"version": "1.8.2",
+	"version": "1.8.3",
 	"private": true,
 	"license": "MIT",
 	"main": "src/index.ts",

--- a/packages/webapp/src/components/DataEvaluationInfoDownloader/hooks.ts
+++ b/packages/webapp/src/components/DataEvaluationInfoDownloader/hooks.ts
@@ -122,6 +122,9 @@ export async function getAggregatesCsv(
 		aggregateType,
 		aggregatesDelimiter,
 		combinationDelimiter,
+		// case insensitive sort on combinations values
+		// so it works nice with the PBI report
+		true,
 	)
 	return result?.aggregatesData || ''
 }

--- a/packages/webapp/src/pages/hooks/useOnGetAllAssetsDownloadInfo.ts
+++ b/packages/webapp/src/pages/hooks/useOnGetAllAssetsDownloadInfo.ts
@@ -334,7 +334,7 @@ export async function generateEvaluationSummaryTxt(
 /* eslint-disable @essex/adjacent-await */
 export function useOnGetAllAssetsDownloadInfo(
 	delimiter = ',',
-	alias = 'all_assets',
+	alias = 'sds_all_assets',
 ): () => Promise<DownloadInfo | undefined> {
 	const [manager] = useSdsManagerInstance()
 	const allSynthesisInfo = useAllFinishedSynthesisInfo()

--- a/packages/webapp/src/workers/SdsManager.ts
+++ b/packages/webapp/src/workers/SdsManager.ts
@@ -210,6 +210,7 @@ export class SdsManager {
 		aggregateType: AggregateType,
 		aggregatesDelimiter: string,
 		combinationDelimiter: string,
+		caseInsensitiveCombinationsOrder = false,
 	): Promise<IAggregateResult> {
 		return await this.getSynthesizerWorkInfo(
 			key,
@@ -217,6 +218,7 @@ export class SdsManager {
 			aggregateType,
 			aggregatesDelimiter,
 			combinationDelimiter,
+			caseInsensitiveCombinationsOrder,
 		)
 	}
 

--- a/packages/webapp/src/workers/WasmSynthesizer.ts
+++ b/packages/webapp/src/workers/WasmSynthesizer.ts
@@ -110,6 +110,7 @@ export class WasmSynthesizer extends BaseSdsWasmWorker {
 		aggregateType: AggregateType,
 		aggregatesDelimiter: string,
 		combinationDelimiter: string,
+		caseInsensitiveCombinationsOrder = false,
 	): Promise<IAggregateResult> {
 		const context = this.getContext()
 
@@ -118,16 +119,19 @@ export class WasmSynthesizer extends BaseSdsWasmWorker {
 				return context.sensitiveAggregateResultToJs(
 					aggregatesDelimiter,
 					combinationDelimiter,
+					caseInsensitiveCombinationsOrder,
 				)
 			case AggregateType.Aggregated:
 				return context.reportableAggregateResultToJs(
 					aggregatesDelimiter,
 					combinationDelimiter,
+					caseInsensitiveCombinationsOrder,
 				)
 			case AggregateType.Synthetic:
 				return context.syntheticAggregateResultToJs(
 					aggregatesDelimiter,
 					combinationDelimiter,
+					caseInsensitiveCombinationsOrder,
 				)
 		}
 	}


### PR DESCRIPTION
- Case insensitive order for aggregates exported from the UI (PBI compatibility)
- Updated aggregates sorting (combination length ascending / count descending)
- Renaming all assets download to `sds_all_assets.zip`
- Version 1.8.3